### PR TITLE
No need to remove domains manually

### DIFF
--- a/gather-domains.sh
+++ b/gather-domains.sh
@@ -25,11 +25,6 @@ scripts/fed_hostnames.py --output-file=$OUTPUT_DIR/cyhy_fed_hostnames.csv
 # modifies the fields in the CSV, so we'll use wget here.
 wget https://raw.githubusercontent.com/GSA/data/master/dotgov-domains/current-federal.csv \
      -O $OUTPUT_DIR/current-federal_modified.csv
-# Now remove the domains ofheo.gov and fhfb.gov.  FHFA has advised us
-# that these domains are no longer registered, but they are still in
-# current-federal.  Once issue #103 in GSA/data has been resolved,
-# this sed command can be removed.
-sed -i '/^FHFB\.GOV,/d;/^OFHEO\.GOV,/d' $OUTPUT_DIR/current-federal_modified.csv
 # Remove all domains that belong to US Courts, since they are part of
 # the judicial branch and have asked us to stop scanning them.
 sed -i '/[^,]*,[^,]*,U.S Courts,/d;' $OUTPUT_DIR/current-federal_modified.csv


### PR DESCRIPTION
There is no need to remove fhfb.gov and ofheo.gov manually.  These domains were removed from GSA's current federal in [this pull request](https://github.com/GSA/data/pull/105).